### PR TITLE
use #not_eq instead of #neq

### DIFF
--- a/src/main/java/com/camertron/Scuttle/ValueExpressionVisitor.java
+++ b/src/main/java/com/camertron/Scuttle/ValueExpressionVisitor.java
@@ -424,7 +424,7 @@ public class ValueExpressionVisitor extends ScuttleBaseVisitor {
       case SQLParser.NULL:
         return "eq";
       case SQLParser.NOT_EQUAL:
-        return "neq";
+        return "not_eq";
       case SQLParser.GTH:
         return "gt";
       case SQLParser.LTH:


### PR DESCRIPTION
Not sure if/when it changed...

http://www.rubydoc.info/gems/arel/Arel/Predications#not_eq-instance_method
